### PR TITLE
Adding Ingress resource to LangKit Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## How to Use WhyLabs Helm Repository
 
-> WhyLab's Helm charts are currently hosted on the GitHub Container Registry
-> (GHCR), an OCI-compliant storage solution. While GHCR differs from traditional
-> Helm repositories by not providing an index.yaml file for chart listings, it
-> aligns with industry standards for container artifact storage. As we explore
-> more comprehensive repository solutions, please use the `helm pull` command,
-> followed by specifying the chart's .tgz file, to access and utilize our Helm
-> charts.
+> :warning: WhyLab's Helm charts are currently hosted on the GitHub Container
+> Registry (GHCR), an OCI-compliant storage solution. While GHCR differs from
+> traditional Helm repositories by not providing an index.yaml file for chart
+> listings, it aligns with industry standards for container artifact storage. As
+> we exploremore comprehensive repository solutions, please use the `helm pull`
+> command,followed by specifying the chart's .tgz file, to access and utilize
+> our Helm charts.
 
 ### Example Using the [LangKit Helm Chart](./charts/langkit/)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # Helm Charts for WhyLabs
 
-## How to use WhyLabs Helm repository
+## How to Use WhyLabs Helm Repository
+
+> WhyLab's Helm charts are currently hosted on the GitHub Container Registry
+> (GHCR), an OCI-compliant storage solution. While GHCR differs from traditional
+> Helm repositories by not providing an index.yaml file for chart listings, it
+> aligns with industry standards for container artifact storage. As we explore
+> more comprehensive repository solutions, please use the `helm pull` command,
+> followed by specifying the chart's .tgz file, to access and utilize our Helm
+> charts.
 
 ### Example Using the [LangKit Helm Chart](./charts/langkit/)
 
 #### Quick Start
+WhyLab's Helm charts are stored in an OCI repository 
 ```shell
+# Downloads a .tgz file to the working directory or --destination path
 helm pull \
   oci://ghcr.io/whylabs/langkit \
   --version "0.2.0"
@@ -15,6 +25,7 @@ helm diff upgrade \
   `# set namespace.create to false if the target namespace already exists` \
   --set namespace.create=false \
   --namespace langkit \
+  `# Specify the .tgz file as the chart` \
   langkit langkit-0.2.0.tgz
 
 helm upgrade --install \
@@ -44,11 +55,11 @@ helm pull \
 
 # Performs a diff between current and proposed state
 # --allow-unreleased flag will perform a diff even if there is no current state,
-# i.e. a fresh installation will display all net new resource creation in the diff.
-# --set namespace.create=false must be set if target namespace already exists;
-# omit this line or set it to "true" if the target namespace should be created.
-# Requires the helm-diff plugin to be installed:
-# helm plugin install https://github.com/databus23/helm-diff
+# i.e. a fresh installation will display all net new resource creation in the
+# diff. --set namespace.create=false must be set if target namespace already
+# exists; omit this line or set it to "true" if the target namespace should be
+# created. Requires the helm-diff plugin to be installed:
+# `helm plugin install https://github.com/databus23/helm-diff`
 helm diff upgrade \
   --allow-unreleased \
   `# set namespace.create to false if the target namespace already exists` \
@@ -57,9 +68,9 @@ helm diff upgrade \
   "${release}" "${chart}"
 
 # helm upgrade --install supports installation and upgrades.
-# In the `helm upgrade --install <release-name> <chart>` command, the chart may be
-# a chart reference('example/postgres'), a path to a chart directory, a fully qualified
-# URL, or a packaged chart (which is what this example uses)
+# In the `helm upgrade --install <release-name> <chart>` command, the chart may
+# be a chart reference('example/postgres'), a path to a chart directory, a fully
+# qualified URL, or a packaged chart (.tgz), which is what this example uses.
 helm upgrade --install \
   `# set namespace.create to false if the target namespace already exists` \
   --set namespace.create=false \

--- a/charts/langkit/CHANGELOG.md
+++ b/charts/langkit/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning]
+(https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2024-01-23
+
+### Added
+
+- Ingress resource
+
+### Changed
+
+- Documented working with GitHub Container Registry (GHCR), an OCI-compliant
+  storage solution 

--- a/charts/langkit/Chart.yaml
+++ b/charts/langkit/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langkit
 description: A Helm chart for LangKit container deployment
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.0.28"

--- a/charts/langkit/README.md
+++ b/charts/langkit/README.md
@@ -1,12 +1,18 @@
-# langkit
+# LangKit Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+> :warning: Review the [documentation on using WhyLab's Helm charts](../../README.md#how-to-use-whylabs-helm-repository)
 
 ## Prerequisites
 
 ### Credentials
 
-The following Kubernetes `Secrets` must exist in the cluster prior to installing this Helm chart: `whylabs-api-secret` and `langkit-api-secret`. The following commands can be used to create the `Secrets` within the cluster.
+The following Kubernetes `Secrets` must exist in the cluster prior to installing
+this Helm chart: `whylabs-api-secret` and `langkit-api-secret`. The following
+commands can be used to create the `Secrets` within the cluster.
 
 ```shell
 kubectl create secret generic whylabs-api-secret \
@@ -62,7 +68,8 @@ helm uninstall \
 
 ### Generate Values Table
 
-The following command will output the [Values table](#values) below. Copy and paste the table into this `README.md` file whenever this chart changes.
+The following command will output the [Values table](#values) below. Copy and
+paste the table into this `README.md` file whenever this chart changes.
 
 ```shell
 helm-docs --dry-run
@@ -78,6 +85,13 @@ helm-docs --dry-run
 | image.repository | string | `"whylabs/whylogs"` |  |
 | image.tag | string | `"py-llm-latest"` |  |
 | imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
 | livenessProbe.initialDelaySeconds | int | `15` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.tcpSocket.port | int | `8000` |  |
@@ -96,8 +110,8 @@ helm-docs --dry-run
 | resources.limits.memory | string | `"16Gi"` |  |
 | resources.requests.cpu | string | `"4"` |  |
 | resources.requests.memory | string | `"8Gi"` |  |
-| secrets.langkitApiSecret | object | `{"name":"langkit-api-secret"}` | |
-| secrets.whylabsApiKey | object | `{"name":"whylabs-api-key"}` | |
+| secrets.langkitApiSecret.name | string | `"langkit-api-secret"` |  |
+| secrets.whylabsApiKey.name | string | `"whylabs-api-key"` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/langkit/templates/ingress.yaml
+++ b/charts/langkit/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "langkit.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "langkit.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/langkit/values.yaml
+++ b/charts/langkit/values.yaml
@@ -15,6 +15,22 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
## Changes
- Add ingress resource to LangKit helm chart
- Update documentation for clarity on OCI compliant helm repos vs more traditional repos
- Added changelog

## Testing
### Adding ingress-nginx to Azure cluster for testing
```shell
helm upgrade --install ingress-nginx ingress-nginx \
  --set 'controller.tolerations[0].key=kubernetes.azure.com/scalesetpriority' \
  --set 'controller.tolerations[0].operator=Exists' \
  --set 'controller.tolerations[0].effect=NoSchedule' \
  --set 'defaultBackend.tolerations[0].key=kubernetes.azure.com/scalesetpriority' \
  --set 'defaultBackend.tolerations[0].operator=Exists' \
  --set 'defaultBackend.tolerations[0].effect=NoSchedule' \
  --set 'controller.admissionWebhooks.patch.tolerations[0].key=kubernetes.azure.com/scalesetpriority' \
  --set 'controller.admissionWebhooks.patch.tolerations[0].operator=Exists' \
  --set 'controller.admissionWebhooks.patch.tolerations[0].effect=NoSchedule' \
  --set 'controller.admissionWebhooks.install.tolerations[0].key=kubernetes.azure.com/scalesetpriority' \
  --set 'controller.admissionWebhooks.install.tolerations[0].operator=Exists' \
  --set 'controller.admissionWebhooks.install.tolerations[0].effect=NoSchedule' \
  --set 'defaultBackend.enabled=true" \
  --repo https://kubernetes.github.io/ingress-nginx \
  --namespace ingress-nginx --create-namespace

# Uninstall
helm uninstall -n ingress-nginx ingress-nginx
```

### Upgrade langkit Helm chart
```shell
# Download latest version of the chart
helm pull \
  oci://ghcr.io/whylabs/langkit \
  --version "0.3.0"

# Confirm changes prior to upgrade
helm diff upgrade \
  --set namespace.create=false \
  --set ingress.enabled=true \
  --set ingress.className=nginx \
  --set 'ingress.hosts[0].paths[0].path=/langkit' \
  --set 'ingress.hosts[0].paths[0].pathType=ImplementationSpecific' \
  --set 'ingress.hosts[0].paths[0].backend.service.name=langkit' \
  --set 'ingress.hosts[0].paths[0].backend.service.port.number=80' \
  --namespace langkit \
  langkit langkit-0.3.0.tgz

# Perform the upgrade
helm upgrade --install \
  --set namespace.create=false \
  --set ingress.enabled=true \
  --set ingress.className=nginx \
  --set 'ingress.hosts[0].paths[0].path=/langkit' \
  --set 'ingress.hosts[0].paths[0].pathType=ImplementationSpecific' \
  --set 'ingress.hosts[0].paths[0].backend.service.name=langkit' \
  --set 'ingress.hosts[0].paths[0].backend.service.port.number=80' \
  --namespace langkit \
  langkit langkit-0.3.0.tgz
```

The langkit helm chart 0.3.0 upgrade produces this ingress resource:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    meta.helm.sh/release-name: langkit
    meta.helm.sh/release-namespace: langkit
  labels:
    app.kubernetes.io/instance: langkit
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: langkit
    app.kubernetes.io/version: 0.0.28
    helm.sh/chart: langkit-0.3.0
  name: langkit
  namespace: langkit
spec:
  ingressClassName: nginx
  rules:
  - http:
      paths:
      - backend:
          service:
            name: langkit
            port:
              number: 80
        path: /langkit
        pathType: ImplementationSpecific
status:
  loadBalancer:
    ingress:
    - ip: 20.29.145.44
```

### Test the Ingress
```shell
kubectl port-forward service/ingress-nginx-controller -n ingress-nginx 8080:80 &
curl http://localhost:8080/langkit
```

#### Logs from nginx
```shell
127.0.0.1 - - [23/Jan/2024:20:55:11 +0000] "GET /langkit HTTP/1.1" 404 22 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" 694 0.002 [langkit-langkit-80] [] 10.224.0.226:8000 22 0.003 404 0e1fa326f3f9efbcf42d27cf89b42257
```

#### Logs from langkit
```shell
INFO:     10.224.0.105:32786 - "GET /langkit HTTP/1.1" 404 Not Found
```