### PR TITLE
Upgrade default image

### DIFF
--- a/charts/langkit/CHANGELOG.md
+++ b/charts/langkit/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning]
 (https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-01-30
+
+### Changed
+
+- Updated the default image version from `py-llm-1.0.2.dev0` to `py-llm-1.0.2.dev1`
+- Default `tolerations` is set to `[]`
+
 ## [0.4.0] - **Breaking Changes** - 2023-01-26
 
 ### Added

--- a/charts/langkit/Chart.yaml
+++ b/charts/langkit/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langkit
 description: A Helm chart for LangKit container deployment
 type: application
-version: 0.4.0
-appVersion: "1.0.1"
+version: 0.5.0
+appVersion: "1.0.2.dev1"

--- a/charts/langkit/README.md
+++ b/charts/langkit/README.md
@@ -122,10 +122,7 @@ helm-docs --dry-run
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
-| tolerations[0].effect | string | `"NoSchedule"` |  |
-| tolerations[0].key | string | `"kubernetes.azure.com/scalesetpriority"` |  |
-| tolerations[0].operator | string | `"Equal"` |  |
-| tolerations[0].value | string | `"spot"` |  |
+| tolerations | list | `[]` |  |
 | volumeMounts[0].mountPath | string | `"/tmp"` |  |
 | volumeMounts[0].name | string | `"temp-dir"` |  |
 | volumeMounts[1].mountPath | string | `"/root/.config"` |  |

--- a/charts/langkit/values.yaml
+++ b/charts/langkit/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 3
 image:
   repository: whylabs/whylogs
   pullPolicy: IfNotPresent
-  tag: py-llm-1.0.2.dev0
+  tag: py-llm-1.0.2.dev1
   containerPort: 8000
 
 imagePullSecrets: []
@@ -77,11 +77,11 @@ readinessProbe:
 
 nodeSelector: {}
 
-tolerations:
-  - effect: NoSchedule
-    key: kubernetes.azure.com/scalesetpriority
-    operator: Equal
-    value: spot
+tolerations: []
+  # - effect: NoSchedule
+  #   key: kubernetes.azure.com/scalesetpriority
+  #   operator: Equal
+  #   value: spot
 
 affinity:
   podAntiAffinity:


### PR DESCRIPTION
Azure deployment diff
```diff
langkit, langkit, Deployment (apps) has changed:
  # Source: langkit/templates/deployment.yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: langkit
    labels:
-     helm.sh/chart: langkit-0.4.0
+     helm.sh/chart: langkit-0.5.0
      app.kubernetes.io/name: langkit
      app.kubernetes.io/instance: langkit
-     app.kubernetes.io/version: "1.0.1"
+     app.kubernetes.io/version: "1.0.2.dev1"
      app.kubernetes.io/managed-by: Helm
  spec:
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: langkit
        app.kubernetes.io/instance: langkit
    template:
      metadata:
        labels:
-         helm.sh/chart: langkit-0.4.0
+         helm.sh/chart: langkit-0.5.0
          app.kubernetes.io/name: langkit
          app.kubernetes.io/instance: langkit
-         app.kubernetes.io/version: "1.0.1"
+         app.kubernetes.io/version: "1.0.2.dev1"
          app.kubernetes.io/managed-by: Helm
      spec:
        securityContext:
          {}
        containers:
          - name: langkit
            securityContext:
              readOnlyRootFilesystem: true
            image: "whylabs/whylogs:py-llm-1.0.2.dev0"
            imagePullPolicy: IfNotPresent
            ports:
              - containerPort: 8000
            livenessProbe:
              initialDelaySeconds: 15
              periodSeconds: 10
              tcpSocket:
                port: 8000
            readinessProbe:
              initialDelaySeconds: 15
              periodSeconds: 10
              tcpSocket:
                port: 8000
            resources:
              limits:
                cpu: "8"
                memory: 16Gi
              requests:
                cpu: "4"
                memory: 8Gi
            envFrom:
              - secretRef:
                  name: whylabs-api-key
              - secretRef:
                  name: langkit-api-secret
            volumeMounts:
              - mountPath: /tmp
                name: temp-dir
              - mountPath: /root/.config
                name: root-config
        volumes:
          - emptyDir: {}
            name: temp-dir
          - emptyDir: {}
            name: root-config
        affinity:
          podAntiAffinity:
            preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchExpressions:
                  - key: app.kubernetes.io/name
                    operator: In
                    values:
                    - langkit
                topologyKey: kubernetes.io/hostname
              weight: 100
        tolerations:
          - effect: NoSchedule
            key: kubernetes.azure.com/scalesetpriority
            operator: Equal
            value: spot
langkit, langkit, Service (v1) has changed:
  # Source: langkit/templates/service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: langkit
    labels:
-     helm.sh/chart: langkit-0.4.0
+     helm.sh/chart: langkit-0.5.0
      app.kubernetes.io/name: langkit
      app.kubernetes.io/instance: langkit
-     app.kubernetes.io/version: "1.0.1"
+     app.kubernetes.io/version: "1.0.2.dev1"
      app.kubernetes.io/managed-by: Helm
  spec:
    type: LoadBalancer
    ports:
      - protocol: TCP
        port: 80
        targetPort: 8000
    selector:
      app.kubernetes.io/name: langkit
      app.kubernetes.io/instance: langkit
```