### PR TITLE
dev/aberg/fix doc #86azhrbm9

### DIFF
--- a/charts/langkit/README.md
+++ b/charts/langkit/README.md
@@ -35,9 +35,9 @@ kubectl create secret generic langkit-api-secret \
 ```
 kubectl create secret docker-registry langkit-gitlab-registry-secret \
   --docker-server="registry.gitlab.com" \
-  --docker-username="project_55361491_bot_4a4030bd91182991f959fe2a3cdd2762" \
+  --docker-username="project_55361491_bot_5a6afbd67224dd1583ccd6c7987354c3" \
   --docker-password="<token>" \
-  --docker-email="project_55361491_bot_4a4030bd91182991f959fe2a3cdd2762@noreply.gitlab.com" \
+  --docker-email="project_55361491_bot_5a6afbd67224dd1583ccd6c7987354c3@noreply.gitlab.com" \
   --namespace=langkit
 ```
 


### PR DESCRIPTION
- Change image pull secret prefix to be scoped to service rather than organization
- remove http
- fix doc
