### PR TITLE
Add backend service

### DIFF
--- a/charts/guardrails/CHANGELOG.md
+++ b/charts/guardrails/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning]
 (https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2024-08-21
+
+### Added
+
+- Backend service
+
 ## [0.2.1] - 2024-07-25
 
 ### Updated

--- a/charts/guardrails/Chart.yaml
+++ b/charts/guardrails/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: guardrails
 description: A Helm chart for WhyLabs Guardrails
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "1.0.23"

--- a/charts/guardrails/README.md
+++ b/charts/guardrails/README.md
@@ -164,15 +164,15 @@ utilization.
 | backend.enabled | bool | `true` |  |
 | backend.env | object | `{}` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `guardrails` container. |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `guardrails` container. |
-| backend.image.repository | string | `"public.ecr.aws/whylabs-dev/pause"` | Image repository for the `guardrails` container. |
-| backend.image.tag | string | `"service"` | Image tag for the `guardrails` container, this will default to `.Chart.AppVersion` if not set. |
-| backend.livenessProbe | object | `{}` | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |
+| backend.image.repository | string | `"207285235248.dkr.ecr.us-west-2.amazonaws.com/guardrails-backend"` | Image repository for the `guardrails` container. |
+| backend.image.tag | string | `"latest"` | Image tag for the `guardrails` container, this will default to `.Chart.AppVersion` if not set. |
+| backend.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/status","port":8080},"initialDelaySeconds":30,"periodSeconds":30}` | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |
 | backend.podAnnotations | object | `{}` | Annotations to add to the `Pod`. |
 | backend.podLabels | object | `{}` | Labels to add to the `Pod`. |
 | backend.podSecurityContext | object | `{"runAsNonRoot":true}` | [Pod security context](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core), this supports full customisation. |
-| backend.readinessProbe | object | `{}` | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |
+| backend.readinessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/status","port":8080},"initialDelaySeconds":30,"periodSeconds":30}` | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |
 | backend.replicaCount | int | `1` |  |
-| backend.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"250Mi","memory":"500Mi"},"requests":{"cpu":"500m","ephemeral-storage":"250Mi","memory":"500Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `guardrails` container. |
+| backend.resources | object | `{"limits":{"cpu":"1","ephemeral-storage":"250Mi","memory":"1Gi"},"requests":{"cpu":"1","ephemeral-storage":"250Mi","memory":"1Gi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `guardrails` container. |
 | backend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `guardrails` container. |
 | backend.service.annotations | object | `{}` | Service annotations. |
 | backend.service.port | int | `80` | Service HTTP port. |

--- a/charts/guardrails/README.md
+++ b/charts/guardrails/README.md
@@ -1,6 +1,6 @@
 # guardrails
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.23](https://img.shields.io/badge/AppVersion-1.0.23-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.23](https://img.shields.io/badge/AppVersion-1.0.23-informational?style=flat-square)
 
 A Helm chart for WhyLabs Guardrails
 
@@ -75,14 +75,14 @@ release_name=""
 # the working directory or --destination path
 helm pull \
   oci://ghcr.io/whylabs/guardrails \
-  --version 0.2.1
+  --version 0.3.0
 
 # Requires the helm-diff plugin to be installed:
 # helm plugin install https://github.com/databus23/helm-diff
 helm diff upgrade \
   --allow-unreleased \
   --namespace "${target_namespace}" \
-  "${release_name}" guardrails-0.2.1.tgz
+  "${release_name}" guardrails-0.3.0.tgz
 ```
 
 After you've installed the repo you can install the chart.
@@ -91,7 +91,7 @@ After you've installed the repo you can install the chart.
 helm upgrade --install \
   --create-namespace \
   --namespace "${target_namespace}" \
-  "${release_name}" guardrails-0.2.1.tgz
+  "${release_name}" guardrails-0.3.0.tgz
 ```
 
 ## Exposing Guardrails Outside Kubernetes
@@ -161,6 +161,23 @@ utilization.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
 | autoscaling | object | `{"enabled":false,"maxReplicas":100,"minReplicas":1,"targetCPUUtilizationPercentage":70}` | [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) configuration for the `guardrails` container. |
+| backend.enabled | bool | `true` |  |
+| backend.env | object | `{}` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `guardrails` container. |
+| backend.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `guardrails` container. |
+| backend.image.repository | string | `"public.ecr.aws/whylabs-dev/pause"` | Image repository for the `guardrails` container. |
+| backend.image.tag | string | `"service"` | Image tag for the `guardrails` container, this will default to `.Chart.AppVersion` if not set. |
+| backend.livenessProbe | object | `{}` | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |
+| backend.podAnnotations | object | `{}` | Annotations to add to the `Pod`. |
+| backend.podLabels | object | `{}` | Labels to add to the `Pod`. |
+| backend.podSecurityContext | object | `{"runAsNonRoot":true}` | [Pod security context](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core), this supports full customisation. |
+| backend.readinessProbe | object | `{}` | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |
+| backend.replicaCount | int | `1` |  |
+| backend.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"250Mi","memory":"500Mi"},"requests":{"cpu":"500m","ephemeral-storage":"250Mi","memory":"500Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `guardrails` container. |
+| backend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `guardrails` container. |
+| backend.service.annotations | object | `{}` | Service annotations. |
+| backend.service.port | int | `80` | Service HTTP port. |
+| backend.service.targetPort | int | `8080` | The port on which the application container is listening. |
+| backend.service.type | string | `"ClusterIP"` | Service Type, i.e. ClusterIp, LoadBalancer, etc. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | env | object | `{}` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `guardrails` container. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `guardrails` container. |

--- a/charts/guardrails/README.md
+++ b/charts/guardrails/README.md
@@ -184,8 +184,8 @@ utilization.
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `""` | Override the full name of the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `guardrails` container. |
-| image.repository | string | `"registry.gitlab.com/whylabs/langkit-container"` | Image repository for the `guardrails` container. |
-| image.tag | string | `""` | Image tag for the `guardrails` container, this will default to `.Chart.AppVersion` if not set. |
+| image.repository | string | `"207285235248.dkr.ecr.us-west-2.amazonaws.com/guardrails"` | Image repository for the `guardrails` container. |
+| image.tag | string | `"1.0.23"` | Image tag for the `guardrails` container, this will default to `.Chart.AppVersion` if not set. |
 | imagePullSecrets[0] | list | `{"name":""}` | Image pull secrets for the `guardrails` container. Defaults to `whylabs-{{ .Release.Name }}-registry-credentials` if `name: ""`. To exclude The ImagePullSecret entirely, set `imagePullSecrets: []` and comment out the list items. |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) configuration for the `guardrails` container. |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":8000},"initialDelaySeconds":30,"periodSeconds":30}` | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container. |

--- a/charts/guardrails/templates/_helpers.tpl
+++ b/charts/guardrails/templates/_helpers.tpl
@@ -46,11 +46,34 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Common labels - Backend
+*/}}
+{{- define "guardrails.backendLabels" -}}
+helm.sh/chart: {{ include "guardrails.chart" . }}
+{{ include "guardrails.backendSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "guardrails.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "guardrails.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Backend Selector labels
+*/}}
+{{- define "guardrails.backendSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "guardrails.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}-backend
 {{- end }}
 
 {{/*

--- a/charts/guardrails/templates/deployment-backend.yaml
+++ b/charts/guardrails/templates/deployment-backend.yaml
@@ -1,26 +1,25 @@
+{{- if .Values.backend.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "guardrails.fullname" . }}
+  name: {{ include "guardrails.fullname" . }}-backend
   labels:
-    {{- include "guardrails.labels" . | nindent 4 }}
+    {{- include "guardrails.backendLabels" . | nindent 4 }}
 spec:
   revisionHistoryLimit: 3
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: {{ .Values.backend.replicaCount }}
   selector:
     matchLabels:
-      {{- include "guardrails.selectorLabels" . | nindent 6 }}
+      {{- include "guardrails.backendSelectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.backend.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "guardrails.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
+        {{- include "guardrails.backendLabels" . | nindent 8 }}
+        {{- with .Values.backend.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -36,35 +35,30 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "guardrails.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.env }}
+            {{- toYaml .Values.backend.securityContext | nindent 12 }}
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          {{- if .Values.backend.env }}
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
           {{- end }}
-          envFrom:
-            - secretRef:
-                name: whylabs-{{ .Release.Name }}-api-key
-            - secretRef:
-                name: whylabs-{{ .Release.Name }}-api-secret
           ports:
             - name: http
-              containerPort: {{ .Values.service.targetPort }}
+              containerPort: {{ .Values.backend.service.targetPort }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.backend.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.backend.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.backend.resources | nindent 12 }}
           volumeMounts:
             - name: temp-dir
               mountPath: /tmp
@@ -93,3 +87,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end -}}

--- a/charts/guardrails/templates/service-backend.yaml
+++ b/charts/guardrails/templates/service-backend.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.backend.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "guardrails.fullname" . }}-backend
+  labels:
+    {{- include "guardrails.backendLabels" . | nindent 4 }}
+  {{- if .Values.backend.service.annotations }}
+  annotations:
+    {{- .Values.backend.service.annotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.backend.service.port }}
+      targetPort: {{ .Values.backend.service.targetPort }}
+  selector:
+    {{- include "guardrails.backendSelectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/guardrails/values.yaml
+++ b/charts/guardrails/values.yaml
@@ -147,12 +147,12 @@ backend:
 
   image:
     # -- Image repository for the `guardrails` container.
-    repository: public.ecr.aws/whylabs-dev/pause
+    repository: 207285235248.dkr.ecr.us-west-2.amazonaws.com/guardrails-backend
     # -- Image pull policy for the `guardrails` container.
     pullPolicy: IfNotPresent
     # -- (string) Image tag for the `guardrails` container, this will default to
     # `.Chart.AppVersion` if not set.
-    tag: "service"
+    tag: "latest"
 
   service:
     # -- Service annotations.
@@ -191,28 +191,28 @@ backend:
   # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `guardrails` container.
   resources:
     requests:
-      cpu: 500m
-      memory: 500Mi
+      cpu: "1"
+      memory: "1Gi"
       ephemeral-storage: 250Mi
     limits:
-      cpu: 500m
-      memory: 500Mi
+      cpu: "1"
+      memory: "1Gi"
       ephemeral-storage: 250Mi
 
   # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container.
-  livenessProbe: {}
-    # httpGet:
-    #   path: /health
-    #   port: 8000
-    # failureThreshold: 3
-    # initialDelaySeconds: 30
-    # periodSeconds: 30
+  livenessProbe:
+    httpGet:
+      path: /status
+      port: 8080
+    failureThreshold: 3
+    initialDelaySeconds: 30
+    periodSeconds: 30
 
   # -- [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container.
-  readinessProbe: {}
-    # httpGet:
-    #   path: /health
-    #   port: 8000
-    # failureThreshold: 10
-    # initialDelaySeconds: 30
-    # periodSeconds: 30
+  readinessProbe:
+    httpGet:
+      path: /status
+      port: 8080
+    failureThreshold: 10
+    initialDelaySeconds: 30
+    periodSeconds: 30

--- a/charts/guardrails/values.yaml
+++ b/charts/guardrails/values.yaml
@@ -140,3 +140,79 @@ tolerations: []
 
 # -- Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
 affinity: {}
+
+backend:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    # -- Image repository for the `guardrails` container.
+    repository: public.ecr.aws/whylabs-dev/pause
+    # -- Image pull policy for the `guardrails` container.
+    pullPolicy: IfNotPresent
+    # -- (string) Image tag for the `guardrails` container, this will default to
+    # `.Chart.AppVersion` if not set.
+    tag: "service"
+
+  service:
+    # -- Service annotations.
+    annotations: {}
+    # -- Service Type, i.e. ClusterIp, LoadBalancer, etc.
+    type: ClusterIP
+    # -- Service HTTP port.
+    port: 80
+    # -- The port on which the application container is listening.
+    targetPort: 8080
+
+  # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `guardrails` container.
+  env: {}
+    # MY_ENV_VAR: "my env var value"
+
+  # -- Annotations to add to the `Pod`.
+  podAnnotations: {}
+
+  # -- Labels to add to the `Pod`.
+  podLabels: {}
+
+  # -- [Pod security context](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core), this supports full customisation.
+  podSecurityContext:
+    runAsNonRoot: true
+
+  # -- [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `guardrails` container.
+  securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    capabilities:
+      drop: ["ALL"]
+
+  # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `guardrails` container.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+      ephemeral-storage: 250Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
+      ephemeral-storage: 250Mi
+
+  # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container.
+  livenessProbe: {}
+    # httpGet:
+    #   path: /health
+    #   port: 8000
+    # failureThreshold: 3
+    # initialDelaySeconds: 30
+    # periodSeconds: 30
+
+  # -- [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `guardrails` container.
+  readinessProbe: {}
+    # httpGet:
+    #   path: /health
+    #   port: 8000
+    # failureThreshold: 10
+    # initialDelaySeconds: 30
+    # periodSeconds: 30

--- a/charts/guardrails/values.yaml
+++ b/charts/guardrails/values.yaml
@@ -3,12 +3,12 @@ replicaCount: 4
 
 image:
   # -- Image repository for the `guardrails` container.
-  repository: registry.gitlab.com/whylabs/langkit-container
+  repository: 207285235248.dkr.ecr.us-west-2.amazonaws.com/guardrails
   # -- Image pull policy for the `guardrails` container.
   pullPolicy: IfNotPresent
   # -- (string) Image tag for the `guardrails` container, this will default to
   # `.Chart.AppVersion` if not set.
-  tag: ""
+  tag: "1.0.23"
 
 imagePullSecrets:
   # -- (list) Image pull secrets for the `guardrails` container. Defaults to


### PR DESCRIPTION
# `helm template` command output

```yaml
---
# Source: guardrails/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: guardrails
  labels:
    helm.sh/chart: guardrails-0.3.0
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails
    app.kubernetes.io/version: "1.0.23"
    app.kubernetes.io/managed-by: Helm
automountServiceAccountToken: true
---
# Source: guardrails/templates/service-backend.yaml
apiVersion: v1
kind: Service
metadata:
  name: guardrails-backend
  labels:
    helm.sh/chart: guardrails-0.3.0
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails-backend
    app.kubernetes.io/version: "1.0.23"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: http
      protocol: TCP
      port: 80
      targetPort: 8080
  selector:
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails-backend
---
# Source: guardrails/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: guardrails
  labels:
    helm.sh/chart: guardrails-0.3.0
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails
    app.kubernetes.io/version: "1.0.23"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: http
      protocol: TCP
      port: 80
      targetPort: 8000
  selector:
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails
---
# Source: guardrails/templates/deployment-backend.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: guardrails-backend
  labels:
    helm.sh/chart: guardrails-0.3.0
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails-backend
    app.kubernetes.io/version: "1.0.23"
    app.kubernetes.io/managed-by: Helm
spec:
  revisionHistoryLimit: 3
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: guardrails
      app.kubernetes.io/instance: guardrails-backend
  template:
    metadata:
      labels:
        helm.sh/chart: guardrails-0.3.0
        app.kubernetes.io/name: guardrails
        app.kubernetes.io/instance: guardrails-backend
        app.kubernetes.io/version: "1.0.23"
        app.kubernetes.io/managed-by: Helm
    spec:
      imagePullSecrets:
        - name: whylabs-guardrails-registry-credentials
      serviceAccountName: guardrails
      securityContext:
        runAsNonRoot: true
      containers:
        - name: guardrails
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          image: "207285235248.dkr.ecr.us-west-2.amazonaws.com/guardrails-backend:latest"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /status
              port: 8080
            initialDelaySeconds: 30
            periodSeconds: 30
          readinessProbe:
            failureThreshold: 10
            httpGet:
              path: /status
              port: 8080
            initialDelaySeconds: 30
            periodSeconds: 30
          resources:
            limits:
              cpu: "1"
              ephemeral-storage: 250Mi
              memory: 1Gi
            requests:
              cpu: "1"
              ephemeral-storage: 250Mi
              memory: 1Gi
          volumeMounts:
            - name: temp-dir
              mountPath: /tmp
      volumes:
        - name: temp-dir
          emptyDir: {}
---
# Source: guardrails/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: guardrails
  labels:
    helm.sh/chart: guardrails-0.3.0
    app.kubernetes.io/name: guardrails
    app.kubernetes.io/instance: guardrails
    app.kubernetes.io/version: "1.0.23"
    app.kubernetes.io/managed-by: Helm
spec:
  revisionHistoryLimit: 3
  replicas: 4
  selector:
    matchLabels:
      app.kubernetes.io/name: guardrails
      app.kubernetes.io/instance: guardrails
  template:
    metadata:
      labels:
        helm.sh/chart: guardrails-0.3.0
        app.kubernetes.io/name: guardrails
        app.kubernetes.io/instance: guardrails
        app.kubernetes.io/version: "1.0.23"
        app.kubernetes.io/managed-by: Helm
    spec:
      imagePullSecrets:
        - name: whylabs-guardrails-registry-credentials
      serviceAccountName: guardrails
      securityContext:
        runAsNonRoot: true
      containers:
        - name: guardrails
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          image: "207285235248.dkr.ecr.us-west-2.amazonaws.com/guardrails:1.0.23"
          imagePullPolicy: IfNotPresent
          envFrom:
            - secretRef:
                name: whylabs-guardrails-api-key
            - secretRef:
                name: whylabs-guardrails-api-secret
          ports:
            - name: http
              containerPort: 8000
              protocol: TCP
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /health
              port: 8000
            initialDelaySeconds: 30
            periodSeconds: 30
          readinessProbe:
            failureThreshold: 10
            httpGet:
              path: /health
              port: 8000
            initialDelaySeconds: 30
            periodSeconds: 30
          resources:
            limits:
              cpu: "4"
              ephemeral-storage: 250Mi
              memory: 4Gi
            requests:
              cpu: "4"
              ephemeral-storage: 250Mi
              memory: 4Gi
          volumeMounts:
            - name: temp-dir
              mountPath: /tmp
      volumes:
        - name: temp-dir
          emptyDir: {}
```