### PR TITLE
Fix extraVolumeMounts and bump default image

### DIFF
--- a/charts/guardrails/CHANGELOG.md
+++ b/charts/guardrails/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning]
 (https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-09-04
+
+### Updated
+
+- Default image tag from `1.0.23` to `2.0.1`
+
+### Fixed
+
+- `extraVolumeMounts` was not adding volume mounts as expected.
+
 ## [0.2.1] - 2024-07-25
 
 ### Updated

--- a/charts/guardrails/Chart.yaml
+++ b/charts/guardrails/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: guardrails
 description: A Helm chart for WhyLabs Guardrails
 type: application
-version: 0.2.1
-appVersion: "1.0.23"
+version: 0.2.2
+appVersion: "2.0.1"

--- a/charts/guardrails/README.md
+++ b/charts/guardrails/README.md
@@ -1,6 +1,6 @@
 # guardrails
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.23](https://img.shields.io/badge/AppVersion-1.0.23-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 A Helm chart for WhyLabs Guardrails
 
@@ -75,14 +75,14 @@ release_name=""
 # the working directory or --destination path
 helm pull \
   oci://ghcr.io/whylabs/guardrails \
-  --version 0.2.1
+  --version 0.2.2
 
 # Requires the helm-diff plugin to be installed:
 # helm plugin install https://github.com/databus23/helm-diff
 helm diff upgrade \
   --allow-unreleased \
   --namespace "${target_namespace}" \
-  "${release_name}" guardrails-0.2.1.tgz
+  "${release_name}" guardrails-0.2.2.tgz
 ```
 
 After you've installed the repo you can install the chart.
@@ -91,7 +91,7 @@ After you've installed the repo you can install the chart.
 helm upgrade --install \
   --create-namespace \
   --namespace "${target_namespace}" \
-  "${release_name}" guardrails-0.2.1.tgz
+  "${release_name}" guardrails-0.2.2.tgz
 ```
 
 ## Exposing Guardrails Outside Kubernetes

--- a/charts/guardrails/templates/deployment.yaml
+++ b/charts/guardrails/templates/deployment.yaml
@@ -68,10 +68,8 @@ spec:
           volumeMounts:
             - name: temp-dir
               mountPath: /tmp
-            {{- if .Values.extraVolumeMounts }}
-              {{- with .extraVolumeMounts }}
+            {{- with .Values.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
-              {{- end }}
             {{- end }}
       volumes:
         - name: temp-dir


### PR DESCRIPTION
Specifying `extraVolumes` and `extraVolumeMounts` works as expected now:

```shell
helm template guardrails . \
  --set "extraVolumes[0].name=secret-store-inline" \
  --set "extraVolumes[0].csi.driver=secret-store.csi.k8s.io" \
  --set "extraVolumes[0].csi.volumeAttributes.secretProviderClass=my-provider" \
  --set "extraVolumeMounts[0].name=secret-store-inline" \
  --set "extraVolumeMounts[0].mountPath=/whylabs/secrets" | yq
```

Output:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: guardrails
spec:
  template:
    metadata:
      labels:
        helm.sh/chart: guardrails-0.2.2
        app.kubernetes.io/name: guardrails
    spec:
      containers:
        - name: guardrails
          volumeMounts:
            - name: temp-dir
              mountPath: /tmp
            - mountPath: /whylabs/secrets
              name: secret-store-inline
      volumes:
        - name: temp-dir
          emptyDir: {}
        - csi:
            driver: secret-store.csi.k8s.io
            volumeAttributes:
              secretProviderClass: my-provider
          name: secret-store-inline
```